### PR TITLE
LGT-16677 - Add KC_HTTP_ENABLED to keycloak

### DIFF
--- a/chart/templates/keycloak-deployment.yaml
+++ b/chart/templates/keycloak-deployment.yaml
@@ -216,6 +216,8 @@ spec:
             {{ else }}
             - name: KC_HTTPS_CERTIFICATE_FILE
             - name: KC_HTTPS_CERTIFICATE_KEY_FILE
+            - name: KC_HTTP_ENABLED
+              value: "true"
             {{ end }}
             - name: KC_DB
               value: mysql


### PR DESCRIPTION
This PR is related to [this PR](https://github.com/lightrun-platform/athena/pull/11499) in `athena` repo.

`http-enabled = true` now has to be set explicitly in the latest version of Keycloak.

It can be merged separately from that PR, but should be merged before it, so we don't break Tilt prod profile.