### PR TITLE
DEVOPS-2656-changed-bumped-data-streamer-version

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -887,7 +887,7 @@ deployments:
     rollout_strategy: "RollingUpdate"
     image:
       repository: lightruncom/data-streamer
-      tag: "4.48.1-alpine-3.21.3-r0.lr-0"
+      tag: "4.51-alpine-3.21.3-r0.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 100m


### PR DESCRIPTION
Bump datastreamer to redpanda 4.51.