### PR TITLE
DEVOPS-2761-fixed-not-create-system-configuration-if-content-and-signature-empty

### DIFF
--- a/chart/templates/backend-deployment.yaml
+++ b/chart/templates/backend-deployment.yaml
@@ -60,9 +60,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ template "lightrun-be.serviceAccountName" . }}
       volumes:
+        {{- if and .Values.general.system_config.content .Values.general.system_config.signature }}
         - name: system-config
           configMap:
             name: {{ include "lightrun.fullname" . }}-system-config
+        {{- end }}
         - name: encryption-keys
           secret: 
             secretName: {{ include "secrets.backend.name" . }}
@@ -133,10 +135,12 @@ spec:
             "/usr/src/lightrun/{{ .Values.deployments.backend.jar_name }}"
           ]
           volumeMounts:
+          {{- if and .Values.general.system_config.content .Values.general.system_config.signature }}
             - name: system-config
               mountPath: {{ .Values.general.system_config.file_path }}
               subPath: {{ base .Values.general.system_config.file_path }}
               readOnly: true
+          {{- end }}
             - name: encryption-keys
               mountPath: /encryption-keys
               readOnly: true
@@ -200,10 +204,12 @@ spec:
             - secretRef:
                 name: {{ include "secrets.backend.name" . }}
           env:
+          {{- if and .Values.general.system_config.content .Values.general.system_config.signature }}
             - name: LIGHTRUN_SYSTEM_CONFIG_JSON_FILE_PATH
               value: {{ .Values.general.system_config.file_path }}
             - name: LIGHTRUN_SYSTEM_CONFIG_JSON_SIGNATURE
               value: {{ .Values.general.system_config.signature }}
+          {{- end }}
             - name: SERVER_SECURITY_ENCRYPTION-KEYS-PATH
               value: file:/encryption-keys
             - name: LIGHTRUN_HOSTNAME

--- a/chart/templates/backend-system-config-cm.yaml
+++ b/chart/templates/backend-system-config-cm.yaml
@@ -4,5 +4,5 @@ apiVersion: v1
 metadata:
   name: {{ include "lightrun.fullname" . }}-system-config
 data:
-  system_config.json: {{ .Values.general.system_config.content }}
+  system_config.json: {{ .Values.general.system_config.content | b64dec}}
 {{- end }}

--- a/chart/templates/backend-system-config-cm.yaml
+++ b/chart/templates/backend-system-config-cm.yaml
@@ -1,6 +1,8 @@
+{{- if and .Values.general.system_config.content .Values.general.system_config.signature }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: {{ include "lightrun.fullname" . }}-system-config
 data:
   system_config.json: {{ .Values.general.system_config.content }}
+{{- end }}

--- a/chart/templates/backend-system-config-cm.yaml
+++ b/chart/templates/backend-system-config-cm.yaml
@@ -4,5 +4,5 @@ apiVersion: v1
 metadata:
   name: {{ include "lightrun.fullname" . }}-system-config
 data:
-  system_config.json: {{ .Values.general.system_config.content | b64dec}}
+  system_config.json: {{ .Values.general.system_config.content | b64dec | quote }}
 {{- end }}


### PR DESCRIPTION
…include system configuration settings. This allows for optional integration of a signed JSON config file via ConfigMap.