### PR TITLE
DEVOPS-2763-fixed-cves-in-data-streamer-by-bumping-version-to-4.55.0-cp

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -859,7 +859,7 @@ deployments:
     rollout_strategy: "RollingUpdate"
     image:
       repository: lightruncom/data-streamer
-      tag: "4.54.1-alpine-3.21.3-r0.lr-0"
+      tag: "4.55.0-alpine-3.21.3-r0.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 100m


### PR DESCRIPTION
…(#74)