### PR TITLE
DEVOPS-2781-changed-keycloak-switch-to-statefulset

### DIFF
--- a/chart/templates/helpers/_helpers.tpl
+++ b/chart/templates/helpers/_helpers.tpl
@@ -148,10 +148,10 @@ Container SecurityContext of lightrun keycloak
 {{/*
 helper that return the semver of `deplyoments.keycloak.image.tag`
 In case of invalid semver it return 1.38.0
-We then use the version to set Keycloak properties accordingly in file - templates/keycloak-deployment.yaml
+We then use the version to set Keycloak properties accordingly in file - templates/keycloak-statefulset.yaml
 We need this helper as Keycloak in version 25 onwards introduced hostname:v2 and we want to keep backwards compatability
 More info here - https://www.keycloak.org/docs/25.0.2/upgrading/#migrating-to-25-0-0
-Currently, here is what we do in file templates/keycloak-deployment.yaml:
+Currently, here is what we do in file templates/keycloak-statefulset.yaml:
             {{- $version := include "lightrun-keycloak.getParsedVersion" .Values.deployments.keycloak.image.tag -}}
             {{- if semverCompare ">=1.38.0" $version }}
             - name: KC_HOSTNAME

--- a/chart/templates/keycloak-statefulset.yaml
+++ b/chart/templates/keycloak-statefulset.yaml
@@ -1,6 +1,6 @@
 {{- $version := include "lightrun-keycloak.getSemanticVersion" .Values.deployments.keycloak.image.tag -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "lightrun-keycloak.name" . }}
   labels:
@@ -10,8 +10,9 @@ metadata:
     {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  strategy:
-    type: {{ .Values.deployments.keycloak.rollout_strategy }}
+  serviceName: {{ include "lightrun-keycloak.name" . }}
+  updateStrategy: 
+    type: RollingUpdate
   # For clusters with more than 3 pods, consider changing the number of "owner nodes" as described in
   # https://www.keycloak.org/server/caching#_configuring_caches -> Configuring caches for availability
   replicas: {{ .Values.deployments.keycloak.replicas }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -665,7 +665,6 @@ deployments:
     # https://www.keycloak.org/server/caching#_configuring_caches -> Configuring caches for availability
     clusterMode: true
     replicas: 1
-    rollout_strategy: "Recreate"
     image:
       repository: lightruncom/keycloak
       tag: ""

--- a/docs/components/keycloak.md
+++ b/docs/components/keycloak.md
@@ -1,6 +1,6 @@
 ### Overview
 
-The keycloak service provides the authentication. It is deployed as a Kubernetes pod and can be configured for scaling, resource allocation, and health monitoring.
+The keycloak service provides the authentication. It is deployed as a Kubernetes StatefulSet and can be configured for scaling, resource allocation, health monitoring, and clustering.
 configuration is defined under **`deployments.keycloak`** in the **`values.yaml`**
 ### Configuration Options
 
@@ -21,11 +21,6 @@ configuration is defined under **`deployments.keycloak`** in the **`values.yaml`
   replicas: 1              # Default number of replicas
 ```
 
-#### Deployment Strategy
-
-```yaml
-  rollout_strategy: "Recreate"  # Defines the rollout strategy
-```
 
 #### Image Configuration
 


### PR DESCRIPTION
- Replaced Deployment with a new StatefulSet template for Keycloak
- Removed the `rollout_strategy` configuration from `values.yaml` as it is no longer applicable.
- Updated documentation to reflect the change from deployment to StatefulSet.