### PR TITLE
DEVOPS-2830-removed-the-option-to-configure-general-system-config-file-path

### DIFF
--- a/chart/templates/backend-deployment.yaml
+++ b/chart/templates/backend-deployment.yaml
@@ -137,8 +137,8 @@ spec:
           volumeMounts:
           {{- if and .Values.general.system_config.content .Values.general.system_config.signature }}
             - name: system-config
-              mountPath: {{ .Values.general.system_config.file_path }}
-              subPath: {{ base .Values.general.system_config.file_path }}
+              mountPath: "/opt/lightrun/system_config.json"
+              subPath: "system_config.json"
               readOnly: true
           {{- end }}
             - name: encryption-keys
@@ -206,7 +206,7 @@ spec:
           env:
           {{- if and .Values.general.system_config.content .Values.general.system_config.signature }}
             - name: LIGHTRUN_SYSTEM_CONFIG_JSON_FILE_PATH
-              value: {{ .Values.general.system_config.file_path }}
+              value: "/opt/lightrun/system_config.json"
             - name: LIGHTRUN_SYSTEM_CONFIG_JSON_SIGNATURE
               value: {{ .Values.general.system_config.signature }}
           {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,8 +13,6 @@ general:
   deployment_type: on-prem
 
   system_config:
-    # Path to the system config file
-    file_path: "/opt/lightrun/system_config.json"
     # Content of the system config file, base64 encoded
     content: ""
     # Signature of the system config file, base64 encoded


### PR DESCRIPTION
…t.yaml

- Removed the file_path entry from values.yaml.
- Updated backend-deployment.yaml to use a hardcoded path for the system config file and adjusted the corresponding environment variable.