### PR TITLE
DEVOPS-2901-fixed-cron-helper

### DIFF
--- a/chart/templates/crons/deployment.yaml
+++ b/chart/templates/crons/deployment.yaml
@@ -129,7 +129,7 @@ spec:
             {{- if $mergedExtraEnvs }}
 {{ $mergedExtraEnvs | nindent 12 }}
             {{- end }}
-            {{- if not (include "lightrun-crons.hasJavaOptions" $mergedExtraEnvs) }}
+            {{- if and (not (include "list-of-maps-contains" (list .Values.deployments.crons.extraEnvs "_JAVA_OPTIONS"))) (not (include "list-of-maps-contains" (list .Values.deployments.backend.extraEnvs "_JAVA_OPTIONS"))) }}
             - name: "_JAVA_OPTIONS"
               value: {{- toYaml (include "calculate-heap-size" .Values.deployments.crons) | nindent 21  }}
             {{- end }}

--- a/chart/templates/helpers/_helpers.tpl
+++ b/chart/templates/helpers/_helpers.tpl
@@ -841,20 +841,6 @@ Merge extraEnvs from backend and crons with crons taking precedence for duplicat
 {{- end -}}
 
 {{/*
-Check if merged extraEnvs contain _JAVA_OPTIONS
-Usage: {{ include "lightrun-crons.hasJavaOptions" $mergedExtraEnvs }}
-*/}}
-{{- define "lightrun-crons.hasJavaOptions" -}}
-{{- $mergedEnvs := . | fromYaml -}}
-{{- range $mergedEnvs -}}
-{{- if eq .name "_JAVA_OPTIONS" -}}
-true
-{{- break -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
 ################
 ### Datadog  ###
 ################


### PR DESCRIPTION
Updated the condition for setting _JAVA_OPTIONS to check both crons and backend extraEnvs. Removed the deprecated helper function for checking _JAVA_OPTIONS presence.