### PR TITLE
Revert "DEVOPS-2954-changed-bump redis to 7.2.10 (#116)"

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -841,7 +841,7 @@ deployments:
       enabled: false
     image:
       repository: lightruncom/redis
-      tag: 7.2.10-alpine-3.22.0-r0.lr-0
+      tag: 7.2.9-alpine-3.22.0-r0.lr-0
       pullPolicy: IfNotPresent
     resources:
       cpu: 2000m


### PR DESCRIPTION
This reverts commit ba17dab7af130f1cbb7b14e70943877c013f8712.