### PR TITLE
DEVOPS-2893-fixed-data-streamer-cve-by-bumping-version-to-4.61.0-reverted

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -976,7 +976,7 @@ deployments:
     rollout_strategy: "RollingUpdate"
     image:
       repository: lightruncom/data-streamer
-      tag: "4.61.0-alpine-3.22.0-r0.lr-0"
+      tag: "4.56.0-alpine-3.22.0-r0.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 100m


### PR DESCRIPTION
…1.0 (#123)"

This reverts commit 54ba49ecf31d04c137e2805cbe88cb5c64ff7309.