### PR TITLE
DEVOPS-3146-added-provide-a-way-to-pass-several-certificates-public-keys-in-chart-to-server

### DIFF
--- a/chart/templates/helpers/_backend_crons_shared.tpl
+++ b/chart/templates/helpers/_backend_crons_shared.tpl
@@ -18,6 +18,10 @@ Shared environment variables for backend and crons services
   value: file:/encryption-keys
 - name: LIGHTRUN_HOSTNAME
   value: {{ .Values.general.name }}
+{{- if .Values.certificate.security_pinned_hashes }}
+- name: LIGHTRUN_SECURITY_PINNED_HASHES
+  value: {{ join "," .Values.certificate.security_pinned_hashes | quote }}
+{{- end }}
 - name: POD_NAME
   valueFrom:
     fieldRef:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -430,6 +430,11 @@ certificate:
   ## To reuse an already deployed certificate
   ## This secret has to be deployed in the same namespace as the rest of this chart
 
+  ## Optional SHA-256 SPKI pin hashes for the backend (see docs/installation/certificate.md).
+  ## Supplied as a YAML list; rendered into env LIGHTRUN_SECURITY_PINNED_HASHES as a comma-separated string.
+  ## Use when you need more than one accepted hash (for example overlapping rotation of certificate and private key).
+  security_pinned_hashes: []
+
   tls:
     crt: ""
     key: ""

--- a/docs/advanced/internal_tls.md
+++ b/docs/advanced/internal_tls.md
@@ -5,6 +5,8 @@ By default, internal communication between pods within the cluster is not encryp
 > [!WARNING]
 > Enabling internal TLS increases resource consumption, as additional computational power is required for SSL operations.
 
+When internal TLS is enabled, the backend continues to use the **same mandatory TLS certificate** as for IDE/agent traffic (including certificate pinning). To configure **multiple** accepted pinning hashes during certificate rotation, use `certificate.security_pinned_hashes` in `values.yaml`; see [Managing the TLS Certificate](../installation/certificate.md) (section *Optional: multiple certificate pinning hashes*).
+
 ### Enable Internal TLS
 
 To activate internal TLS, set the `enabled` flag to `true`:

--- a/docs/components/backend.md
+++ b/docs/components/backend.md
@@ -58,6 +58,8 @@ backend:
 extraEnvs: []
 ```
 
+The chart may also set `LIGHTRUN_SECURITY_PINNED_HASHES` when you define `certificate.security_pinned_hashes` (comma-separated SPKI SHA-256 hashes). See [Managing the TLS Certificate](../installation/certificate.md).
+
 #### Security Contexts
 
 ```yaml

--- a/docs/installation/certificate.md
+++ b/docs/installation/certificate.md
@@ -67,6 +67,49 @@ cat my-cert.key | base64
 - When using a **certificate chain**, encode the **full chain** (certificate → intermediate → root) instead of just the certificate.
 - Encoding a misordered chain may result in TLS errors.
 - The **Base64-encoded values must be placed in `values.yaml`** under `certificate.tls`.
+
+## **Optional: multiple certificate pinning hashes (`security_pinned_hashes`)**
+
+The backend exposes the mandatory TLS certificate to IDE plugins and agents and uses **certificate pinning** so clients only trust the expected public key.
+
+By default, pinning follows the certificate currently mounted for the backend (a single expected hash). Set `certificate.security_pinned_hashes` when you need the server to **accept more than one SHA-256 SPKI pin hash at the same time**.
+
+### **Why use more than one hash?**
+
+- **Renewal with the same private key** (re-issue the same CSR): the public key—and therefore the pinning hash—usually **stays the same**, so you often do not need multiple hashes.
+- **Rotation that replaces the private key** (new key pair): the leaf certificate changes and the SPKI hash **changes**. If clients (plugins/agents) still pin the old hash until they are upgraded, you need a **transition window** where **both** the old and new hashes are trusted. Listing both hashes in `security_pinned_hashes` allows that overlap.
+
+At deploy time, the chart sets the backend environment variable `LIGHTRUN_SECURITY_PINNED_HASHES` to the **comma-separated** list of hashes from `values.yaml`.
+
+Example:
+
+```yaml
+certificate:
+  security_pinned_hashes:
+    - "E8F47F3C8B2A1D9E4F6A0B1C2D3E4F5A6B7C8D9E0F1A2B3C4D5E6F708192A0B"
+    - "A1B2C3D4E5F60718293A4B5C6D7E8F90123456789ABCDEF0123456789ABCDEF0"
+```
+
+Use **no spaces** inside each hash string. Order does not matter; include every hash that must be accepted during the overlap period.
+
+### **How to compute the pinning hash**
+
+The value must be the **SHA-256 digest of the DER-encoded Subject Public Key Info (SPKI)** of the certificate’s public key, expressed as **hexadecimal** (64 characters), matching what the Lightrun backend expects for `LIGHTRUN_SECURITY_PINNED_HASHES`.
+
+From a PEM certificate file (for example the same `tls.crt` you deploy in the Kubernetes TLS secret):
+
+```bash
+# SHA-256 of SPKI, hexadecimal (lowercase); take the 64 hex characters only
+openssl x509 -in tls.crt -noout -pubkey \
+  | openssl pkey -pubin -outform der \
+  | openssl dgst -sha256 -hex \
+  | awk '{ print $2 }'
+```
+
+If your tooling reports the digest with uppercase hex, normalize to the format required by your Lightrun version (often case-insensitive; keep one consistent style in `values.yaml`).
+
+You can compute a hash for **each** certificate in a rotation (old and new leaf certs) and list both under `security_pinned_hashes` until all clients have moved to the new pin.
+
 ## **Generating a Self-Signed TLS Certificate (Optional)**
 
 If you don’t already have a TLS certificate, you can generate a self‑signed certificate for testing or development purposes. 


### PR DESCRIPTION
- Introduced `security_pinned_hashes` in `values.yaml` to allow specifying multiple SHA-256 SPKI pin hashes for certificate rotation.
- Updated backend environment variable `LIGHTRUN_SECURITY_PINNED_HASHES` to accept these hashes.
- Enhanced documentation to explain the usage and benefits of multiple pinning hashes during certificate transitions.