### PR TITLE
[cascade] bump chart tags

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1061,7 +1061,7 @@ deployments:
       maxReplicas: 5
     image:
       repository: lightruncom/router
-      tag: "1.28.3-alpine-3.23.0-r4.lr-0"
+      tag: "1.28.3-r2-alpine-3.23.0-r4.lr-0"
       pullPolicy: IfNotPresent
     podSecurityContext: {}
     containerSecurityContext: {}


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 20260527-161211 |
| **Trigger** | manual |
| **Strategy** | minor-patch |

### Chart Tag Updates

| Key | Old | New |
|---|---|---|
| deployments.router.image.tag | 1.28.3-alpine-3.23.0-r4.lr-0 | 1.28.3-r2-alpine-3.23.0-r4.lr-0 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 1/devops | devops | #521 |
| chart/lightrun-helm-chart | lightrun-helm-chart | **this PR** |

### Merge Order

This PR is in **scope chart**. Merge sequence: 0 → 1 → chart.
This is the last scope — all image PRs must be merged first.
