### PR TITLE
DEVOPS-3548-security-bump-chart-tags

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -617,17 +617,17 @@ deployments:
       wait_for_keycloak:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.4-r2.lr-0"
+          tag: "0.3.0-alpine-3.23.4-r4.lr-0"
           pullPolicy: ""
       p12_creator:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.4-r2.lr-0"
+          tag: "0.3.0-alpine-3.23.4-r4.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.4-r2.lr-0"
+          tag: "0.3.0-alpine-3.23.4-r4.lr-0"
           pullPolicy: ""
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
@@ -771,12 +771,12 @@ deployments:
       cluster_cert:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.4-r2.lr-0"
+          tag: "0.3.0-alpine-3.23.4-r4.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.4-r2.lr-0"
+          tag: "0.3.0-alpine-3.23.4-r4.lr-0"
           pullPolicy: ""          
     topologySpreadConstraints: []
     affinity: {}
@@ -841,7 +841,7 @@ deployments:
       enabled: false
     image:
       repository: lightruncom/redis
-      tag: "7.2.14-alpine-3.23.4-r2.lr-0"
+      tag: "7.2.14-alpine-3.23.4-r4.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 2000m
@@ -938,7 +938,7 @@ deployments:
           memory: 128Mi
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.4-r2.lr-0"
+          tag: "0.3.0-alpine-3.23.4-r4.lr-0"
           pullPolicy: ""
     # EmptyDir is used for rabbitmq data when mq.storage is set to 0
     emptyDir:
@@ -976,7 +976,7 @@ deployments:
     rollout_strategy: "RollingUpdate"
     image:
       repository: lightruncom/data-streamer
-      tag: "4.95.0-alpine-3.23.4-r2.lr-0"
+      tag: "4.95.0-alpine-3.23.4-r4.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 100m
@@ -1061,7 +1061,7 @@ deployments:
       maxReplicas: 5
     image:
       repository: lightruncom/router
-      tag: "1.28.3-r2-alpine-3.23.4-r2.lr-0"
+      tag: "1.28.3-r3-alpine-3.23.4-r4.lr-0"
       pullPolicy: IfNotPresent
     podSecurityContext: {}
     containerSecurityContext: {}


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 448060 |
| **Trigger** | manual |
| **Strategy** | patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=448060) |

### Chart Tag Updates

| Key | Old | New |
|---|---|---|
| deployments.backend.initContainers.p12_creator.image.tag | 0.3.0-alpine-3.23.4-r2.lr-0 | 0.3.0-alpine-3.23.4-r4.lr-0 |
| deployments.backend.initContainers.wait_for_keycloak.image.tag | 0.3.0-alpine-3.23.4-r2.lr-0 | 0.3.0-alpine-3.23.4-r4.lr-0 |
| deployments.backend.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.23.4-r2.lr-0 | 0.3.0-alpine-3.23.4-r4.lr-0 |
| deployments.data_streamer.image.tag | 4.95.0-alpine-3.23.4-r2.lr-0 | 4.95.0-alpine-3.23.4-r4.lr-0 |
| deployments.keycloak.initContainers.cluster_cert.image.tag | 0.3.0-alpine-3.23.4-r2.lr-0 | 0.3.0-alpine-3.23.4-r4.lr-0 |
| deployments.keycloak.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.23.4-r2.lr-0 | 0.3.0-alpine-3.23.4-r4.lr-0 |
| deployments.rabbitmq.initContainers.rabbitmq_config.image.tag | 0.3.0-alpine-3.23.4-r2.lr-0 | 0.3.0-alpine-3.23.4-r4.lr-0 |
| deployments.redis.image.tag | 7.2.14-alpine-3.23.4-r2.lr-0 | 7.2.14-alpine-3.23.4-r4.lr-0 |
| deployments.router.image.tag | 1.28.3-r2-alpine-3.23.4-r2.lr-0 | 1.28.3-r3-alpine-3.23.4-r4.lr-0 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | [#539](https://github.com/lightrun-platform/devops/pull/539) |
| 1/athena | athena | [#14503](https://github.com/lightrun-platform/athena/pull/14503) |
| 1/devops | devops | [#540](https://github.com/lightrun-platform/devops/pull/540) |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | [#82](https://github.com/lightrun-platform/lightrun-k8s-operator/pull/82) |
| chart/lightrun-helm-chart | lightrun-helm-chart | **this PR** |

### Merge Order

This PR is in **scope chart**. Merge sequence: 0 → 1 → chart.
This is the last scope — all image PRs must be merged first.
