### PR TITLE
DEVOPS-3582-security-bump-chart-tags

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -587,17 +587,17 @@ deployments:
       wait_for_keycloak:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.0-r4.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
           pullPolicy: ""
       p12_creator:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.0-r4.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.0-r4.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
           pullPolicy: ""
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
@@ -738,12 +738,12 @@ deployments:
       cluster_cert:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.0-r4.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.0-r4.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
           pullPolicy: ""
     topologySpreadConstraints: []
     affinity: {}
@@ -806,7 +806,7 @@ deployments:
       enabled: false
     image:
       repository: lightruncom/redis
-      tag: 7.2.10-alpine-3.23.0-r4.lr-0
+      tag: "7.4.9-alpine-3.24.1-r0.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 2000m
@@ -901,7 +901,7 @@ deployments:
           memory: 128Mi
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.23.0-r4.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
           pullPolicy: ""
     # EmptyDir is used for rabbitmq data when mq.storage is set to 0
     emptyDir:
@@ -938,7 +938,7 @@ deployments:
     rollout_strategy: "RollingUpdate"
     image:
       repository: lightruncom/data-streamer
-      tag: "4.91.0-alpine-3.23.0-r0.lr-0"
+      tag: "4.97.0-alpine-3.24.1-r0.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 100m
@@ -1021,7 +1021,7 @@ deployments:
       maxReplicas: 5
     image:
       repository: lightruncom/router
-      tag: "1.28.3-alpine-3.23.0-r4.lr-0"
+      tag: "1.30.2-r1-alpine-3.24.1-r0.lr-0"
       pullPolicy: IfNotPresent
     podSecurityContext: {}
     containerSecurityContext: {}


### PR DESCRIPTION
Backport of #238 to releases/3.43/official. Updated chart/values.yaml tags:
- deployments.backend.initContainers.p12_creator.image.tag: 0.3.0-alpine-3.23.0-r4.lr-0 → 0.3.0-alpine-3.24.1-r0.lr-0
- deployments.backend.initContainers.wait_for_keycloak.image.tag: 0.3.0-alpine-3.23.0-r4.lr-0 → 0.3.0-alpine-3.24.1-r0.lr-0
- deployments.backend.initContainers.wait_for_rabbitmq.image.tag: 0.3.0-alpine-3.23.0-r4.lr-0 → 0.3.0-alpine-3.24.1-r0.lr-0
- deployments.data_streamer.image.tag: 4.91.0-alpine-3.23.0-r0.lr-0 → 4.97.0-alpine-3.24.1-r0.lr-0
- deployments.keycloak.initContainers.cluster_cert.image.tag: 0.3.0-alpine-3.23.0-r4.lr-0 → 0.3.0-alpine-3.24.1-r0.lr-0
- deployments.keycloak.initContainers.wait_for_rabbitmq.image.tag: 0.3.0-alpine-3.23.0-r4.lr-0 → 0.3.0-alpine-3.24.1-r0.lr-0
- deployments.rabbitmq.initContainers.rabbitmq_config.image.tag: 0.3.0-alpine-3.23.0-r4.lr-0 → 0.3.0-alpine-3.24.1-r0.lr-0
- deployments.redis.image.tag: 7.2.10-alpine-3.23.0-r4.lr-0 → 7.4.9-alpine-3.24.1-r0.lr-0
- deployments.router.image.tag: 1.28.3-alpine-3.23.0-r4.lr-0 → 1.30.2-r1-alpine-3.24.1-r0.lr-0