### PR TITLE
DEVOPS-3588-security-bump-chart-tags

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -914,7 +914,7 @@ deployments:
     useJsonLogFormat: false
     image:
       repository: lightruncom/rabbitmq
-      tag: 4.0.9-alpine.lr-3
+      tag: "4.3.2-alpine.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 500m
@@ -1061,7 +1061,7 @@ deployments:
       maxReplicas: 5
     image:
       repository: lightruncom/router
-      tag: "1.30.2-r1-alpine-3.24.1-r0.lr-0"
+      tag: "1.30.3-r0-alpine-3.24.1-r0.lr-0"
       pullPolicy: IfNotPresent
     podSecurityContext: {}
     containerSecurityContext: {}


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 450497 |
| **Trigger** | manual |
| **Strategy** | minor-patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=450497) |

### Chart Tag Updates

| Key | Old | New |
|---|---|---|
| deployments.rabbitmq.image.tag | 4.0.9-alpine.lr-3 | 4.3.2-alpine.lr-0 |
| deployments.router.image.tag | 1.30.2-r1-alpine-3.24.1-r0.lr-0 | 1.30.3-r0-alpine-3.24.1-r0.lr-0 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | [#549](https://github.com/lightrun-platform/devops/pull/549) |
| 1/devops | devops | [#550](https://github.com/lightrun-platform/devops/pull/550) |
| chart/lightrun-helm-chart | lightrun-helm-chart | **this PR** |

### Merge Order

This PR is in **scope chart**. Merge sequence: 0 → 1 → chart.
This is the last scope — all image PRs must be merged first.
