### PR TITLE
DEVOPS-3604-added-pin-async-profiler-chart-helper-image-instead-of-using-latest

### DIFF
--- a/chart/templates/helpers/_asyncProfiler.tpl
+++ b/chart/templates/helpers/_asyncProfiler.tpl
@@ -1,7 +1,7 @@
 {{- define "asyncProfiler.initContainer.download-async-profiler" -}}
 - name: download-async-profiler
-  image: "lightruncom/chart-helper:latest"
-  imagePullPolicy: IfNotPresent
+  image: "{{ .initContainers.download_async_profiler.image.repository }}:{{ .initContainers.download_async_profiler.image.tag }}"
+  imagePullPolicy: {{ .initContainers.download_async_profiler.image.pullPolicy | default "IfNotPresent" }}
   command: 
     - sh
     - -c
@@ -28,8 +28,8 @@
 
 {{- define "asyncProfiler.container.persist-async-profiler-output-files" -}}
 - name: persist-async-profiler-output-files
-  image: "lightruncom/chart-helper:latest"
-  imagePullPolicy: IfNotPresent
+  image: "{{ .initContainers.persist_async_profiler.image.repository }}:{{ .initContainers.persist_async_profiler.image.tag }}"
+  imagePullPolicy: {{ .initContainers.persist_async_profiler.image.pullPolicy | default "IfNotPresent" }}
   command: 
     - sh
     - -c

--- a/chart/templates/helpers/_backend_asyncProfiler.tpl
+++ b/chart/templates/helpers/_backend_asyncProfiler.tpl
@@ -8,7 +8,7 @@
 
 {{- define "lightrun-backend.container.persist-async-profiler-output-files" -}}
 {{- if and .Values.deployments.backend.asyncProfiler.enabled .Values.deployments.backend.asyncProfiler.persistence.enabled }}  
-{{ include "asyncProfiler.container.persist-async-profiler-output-files" . }}
+{{ include "asyncProfiler.container.persist-async-profiler-output-files" .Values.deployments.backend.asyncProfiler }}
   securityContext: {{- include "lightrun-be.containerSecurityContext" . | indent 4 }}
 {{- end -}}
 {{- end -}}

--- a/chart/templates/helpers/_helpers.tpl
+++ b/chart/templates/helpers/_helpers.tpl
@@ -841,7 +841,7 @@ Cron-specific asyncProfiler helpers
 
 {{- define "lightrun-crons.container.persist-async-profiler-output-files" -}}
 {{- if and .Values.deployments.crons.asyncProfiler.enabled .Values.deployments.crons.asyncProfiler.persistence.enabled }}  
-{{ include "asyncProfiler.container.persist-async-profiler-output-files" . }}
+{{ include "asyncProfiler.container.persist-async-profiler-output-files" .Values.deployments.crons.asyncProfiler }}
   securityContext: {{- include "lightrun-crons.containerSecurityContext" . | indent 4 }}
 {{- end -}}
 {{- end -}}

--- a/chart/templates/helpers/_keycloak_asyncProfiler.tpl
+++ b/chart/templates/helpers/_keycloak_asyncProfiler.tpl
@@ -8,7 +8,7 @@
 
 {{- define "lightrun-keycloak.container.persist-async-profiler-output-files" -}}
 {{- if and .Values.deployments.keycloak.asyncProfiler.enabled .Values.deployments.keycloak.asyncProfiler.persistence.enabled }}  
-{{ include "asyncProfiler.container.persist-async-profiler-output-files" . }}
+{{ include "asyncProfiler.container.persist-async-profiler-output-files" .Values.deployments.keycloak.asyncProfiler }}
   securityContext: {{- include "lightrun-keycloak.containerSecurityContext" . | indent 4 }}
 {{- end -}}
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -663,6 +663,17 @@ deployments:
       # deployments.backend.asyncProfiler.enabled -- Run async-profiler on every backend pod
       ## ref: https://github.com/async-profiler/async-profiler
       enabled: false
+      initContainers:
+        download_async_profiler:
+          image:
+            repository: lightruncom/chart-helper
+            tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+            pullPolicy: ""
+        persist_async_profiler:
+          image:
+            repository: lightruncom/chart-helper
+            tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+            pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
       # deployments.backend.asyncProfiler.arguments -- Configure the async profiler arguments
@@ -728,6 +739,17 @@ deployments:
       # deployments.crons.asyncProfiler.enabled -- Run async-profiler on every crons pod
       ## ref: https://github.com/async-profiler/async-profiler
       enabled: false
+      initContainers:
+        download_async_profiler:
+          image:
+            repository: lightruncom/chart-helper
+            tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+            pullPolicy: ""
+        persist_async_profiler:
+          image:
+            repository: lightruncom/chart-helper
+            tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+            pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
       # deployments.crons.asyncProfiler.arguments -- Configure the async profiler arguments
@@ -803,6 +825,17 @@ deployments:
       # deployments.keycloak.asyncProfiler.enabled -- Run async-profiler on every keycloak pod
       ## ref: https://github.com/async-profiler/async-profiler
       enabled: false
+      initContainers:
+        download_async_profiler:
+          image:
+            repository: lightruncom/chart-helper
+            tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+            pullPolicy: ""
+        persist_async_profiler:
+          image:
+            repository: lightruncom/chart-helper
+            tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+            pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
       # deployments.keycloak.asyncProfiler.arguments -- Configure the async profiler arguments


### PR DESCRIPTION
The async profiler download init-container and persist sidecar hardcoded lightruncom/chart-helper:latest. Move the image to values under each asyncProfiler.initContainers section, pinned to the same tag used by the rest of the chart (0.3.0-alpine-3.24.1-r0.lr-0), and make pullPolicy configurable.