### PR TITLE
DEVOPS-3609-changed-Make p12-creator and KEYSTORE_PATH conditional on internal_tls.enabled

### DIFF
--- a/chart/templates/helpers/_backend_crons_shared.tpl
+++ b/chart/templates/helpers/_backend_crons_shared.tpl
@@ -109,8 +109,12 @@ Shared environment variables for backend and crons services
   value: "443"
 - name: SPRING_FLYWAY_SCHEMAS
   value: {{ .Values.general.db_database }}
+- name: LIGHTRUN_SECURITY_PINNED_CERT_HASH_FILE_PATH
+  value: "/p12/pinned-cert-hash"
+{{- if .Values.general.internal_tls.enabled }}
 - name: KEYSTORE_PATH
   value: "file:/p12/lightrun.p12"
+{{- end }}
 - name: SYSTEM_DEFAULT_USER_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -248,6 +252,26 @@ Shared init containers for backend and crons services
 {{ if .Values.general.mq.enabled }}
 {{- include "lightrun-mq.initContainer.wait-for-rabbitmq" (merge (dict "imageConfig" .Values.deployments.backend.initContainers.wait_for_rabbitmq "securityContext" "lightrun-be.containerSecurityContext") .) }}
 {{- end }}
+- name: pinned-cert-hash-creator
+  image: "{{ .Values.deployments.backend.initContainers.p12_creator.image.repository }}:{{ .Values.deployments.backend.initContainers.p12_creator.image.tag }}"
+  imagePullPolicy: {{ .Values.deployments.backend.initContainers.p12_creator.image.pullPolicy }}
+  securityContext: {{ include "lightrun-be.containerSecurityContext" . | indent 4 }}
+  resources:
+    limits:
+      memory: "100Mi"
+      cpu: "100m"
+    requests:
+      memory: "100Mi"
+      cpu: "100m"
+  volumeMounts:
+  - name: certificates
+    mountPath: /tls
+    readOnly: true
+  - name: p12
+    mountPath: /p12
+  command: ['sh', '-c', 'openssl x509 -in /tls/tls.crt -pubkey -noout | openssl pkey -pubin -outform DER | openssl dgst -sha256 -binary | base64 > /p12/pinned-cert-hash']
+
+{{- if .Values.general.internal_tls.enabled }}
 - name: p12-creator
   image: "{{ .Values.deployments.backend.initContainers.p12_creator.image.repository }}:{{ .Values.deployments.backend.initContainers.p12_creator.image.tag }}"
   imagePullPolicy: {{ .Values.deployments.backend.initContainers.p12_creator.image.pullPolicy }}
@@ -271,6 +295,7 @@ Shared init containers for backend and crons services
   - name: p12
     mountPath: /p12
   command: ['sh', '-c', 'cp /tls/tls.crt /p12/crt.pem && cp /tls/tls.key /p12/key.pem && openssl pkcs12 -export -out /p12/lightrun.p12 -inkey /p12/key.pem -in /p12/crt.pem -passin pass:$KEYSTORE_PASSWORD -passout pass:$KEYSTORE_PASSWORD']
+{{- end }}
 
 {{- if and .Values.general.internal_tls.enabled .Values.general.internal_tls.certificates.existing_ca_secret_name }}  
 - name: root-ca-creator

--- a/chart/templates/helpers/_backend_crons_shared.tpl
+++ b/chart/templates/helpers/_backend_crons_shared.tpl
@@ -111,8 +111,10 @@ Shared environment variables for backend and crons services
   value: {{ .Values.general.db_database }}
 - name: LIGHTRUN_SECURITY_PINNED_CERT_HASH_FILE_PATH
   value: "/p12/pinned-cert-hash"
+{{- if .Values.general.internal_tls.enabled }}
 - name: KEYSTORE_PATH
   value: "file:/p12/lightrun.p12"
+{{- end }}
 - name: SYSTEM_DEFAULT_USER_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -269,6 +271,7 @@ Shared init containers for backend and crons services
     mountPath: /p12
   command: ['sh', '-c', 'openssl x509 -in /tls/tls.crt -pubkey -noout | openssl pkey -pubin -outform DER | openssl dgst -sha256 | awk ''{print $NF}'' > /p12/pinned-cert-hash']
 
+{{- if .Values.general.internal_tls.enabled }}
 - name: p12-creator
   image: "{{ .Values.deployments.backend.initContainers.p12_creator.image.repository }}:{{ .Values.deployments.backend.initContainers.p12_creator.image.tag }}"
   imagePullPolicy: {{ .Values.deployments.backend.initContainers.p12_creator.image.pullPolicy }}
@@ -292,6 +295,7 @@ Shared init containers for backend and crons services
   - name: p12
     mountPath: /p12
   command: ['sh', '-c', 'cp /tls/tls.crt /p12/crt.pem && cp /tls/tls.key /p12/key.pem && openssl pkcs12 -export -out /p12/lightrun.p12 -inkey /p12/key.pem -in /p12/crt.pem -passin pass:$KEYSTORE_PASSWORD -passout pass:$KEYSTORE_PASSWORD']
+{{- end }}
 
 {{- if and .Values.general.internal_tls.enabled .Values.general.internal_tls.certificates.existing_ca_secret_name }}  
 - name: root-ca-creator

--- a/chart/templates/helpers/_backend_crons_shared.tpl
+++ b/chart/templates/helpers/_backend_crons_shared.tpl
@@ -269,7 +269,7 @@ Shared init containers for backend and crons services
     readOnly: true
   - name: p12
     mountPath: /p12
-  command: ['sh', '-c', 'openssl x509 -in /tls/tls.crt -pubkey -noout | openssl pkey -pubin -outform DER | openssl dgst -sha256 -binary | base64 > /p12/pinned-cert-hash']
+  command: ['sh', '-c', 'openssl x509 -in /tls/tls.crt -pubkey -noout | openssl pkey -pubin -outform DER | openssl dgst -sha256 | awk ''{print $NF}'' > /p12/pinned-cert-hash']
 
 {{- if .Values.general.internal_tls.enabled }}
 - name: p12-creator

--- a/chart/templates/helpers/_backend_crons_shared.tpl
+++ b/chart/templates/helpers/_backend_crons_shared.tpl
@@ -111,10 +111,8 @@ Shared environment variables for backend and crons services
   value: {{ .Values.general.db_database }}
 - name: LIGHTRUN_SECURITY_PINNED_CERT_HASH_FILE_PATH
   value: "/p12/pinned-cert-hash"
-{{- if .Values.general.internal_tls.enabled }}
 - name: KEYSTORE_PATH
   value: "file:/p12/lightrun.p12"
-{{- end }}
 - name: SYSTEM_DEFAULT_USER_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -271,7 +269,6 @@ Shared init containers for backend and crons services
     mountPath: /p12
   command: ['sh', '-c', 'openssl x509 -in /tls/tls.crt -pubkey -noout | openssl pkey -pubin -outform DER | openssl dgst -sha256 | awk ''{print $NF}'' > /p12/pinned-cert-hash']
 
-{{- if .Values.general.internal_tls.enabled }}
 - name: p12-creator
   image: "{{ .Values.deployments.backend.initContainers.p12_creator.image.repository }}:{{ .Values.deployments.backend.initContainers.p12_creator.image.tag }}"
   imagePullPolicy: {{ .Values.deployments.backend.initContainers.p12_creator.image.pullPolicy }}
@@ -295,7 +292,6 @@ Shared init containers for backend and crons services
   - name: p12
     mountPath: /p12
   command: ['sh', '-c', 'cp /tls/tls.crt /p12/crt.pem && cp /tls/tls.key /p12/key.pem && openssl pkcs12 -export -out /p12/lightrun.p12 -inkey /p12/key.pem -in /p12/crt.pem -passin pass:$KEYSTORE_PASSWORD -passout pass:$KEYSTORE_PASSWORD']
-{{- end }}
 
 {{- if and .Values.general.internal_tls.enabled .Values.general.internal_tls.certificates.existing_ca_secret_name }}  
 - name: root-ca-creator


### PR DESCRIPTION
## Phase 2 of DEVOPS-3557

Phase 1 (PR #236) introduced the `pinned-cert-hash-creator` init container and `LIGHTRUN_SECURITY_PINNED_CERT_HASH_FILE_PATH` env var so the backend can derive the pinned cert hash without needing the private key.

Now that the backend no longer needs the PKCS12 for hash generation alone, this PR makes `p12-creator` conditional — it only runs when `internal_tls.enabled=true` (where the PKCS12 is still needed as the TLS server cert).

## Changes

- `p12-creator` init container wrapped in `{{- if .Values.general.internal_tls.enabled }}`
- - `KEYSTORE_PATH` env var wrapped in `{{- if .Values.general.internal_tls.enabled }}`
## Result

- `internal_tls=false`: no PKCS12 created, private key never written to any shared volume
- - `internal_tls=true`: both `pinned-cert-hash-creator` and `p12-creator` run as before
## Dependencies

- Blocked by PR #236 (DEVOPS-3557) — must be merged first
- - RnD must ensure backend handles absent `KEYSTORE_PATH` gracefully when `LIGHTRUN_SECURITY_PINNED_CERT_HASH_FILE_PATH` is set and `internal_tls=false`