### PR TITLE
DEVOPS-3659-security-bump-chart-tags

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -587,17 +587,17 @@ deployments:
       wait_for_keycloak:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r1.lr-0"
           pullPolicy: ""
       p12_creator:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r1.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r1.lr-0"
           pullPolicy: ""
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
@@ -738,12 +738,12 @@ deployments:
       cluster_cert:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r1.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r1.lr-0"
           pullPolicy: ""
     topologySpreadConstraints: []
     affinity: {}
@@ -806,7 +806,7 @@ deployments:
       enabled: false
     image:
       repository: lightruncom/redis
-      tag: "7.4.9-alpine-3.24.1-r0.lr-0"
+      tag: "7.4.9-alpine-3.24.1-r1.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 2000m
@@ -877,7 +877,7 @@ deployments:
     useJsonLogFormat: false
     image:
       repository: lightruncom/rabbitmq
-      tag: "4.3.2-alpine.lr-0"
+      tag: "4.3.2-alpine.lr-1"
       pullPolicy: IfNotPresent
     resources:
       cpu: 500m
@@ -901,7 +901,7 @@ deployments:
           memory: 128Mi
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r0.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r1.lr-0"
           pullPolicy: ""
     # EmptyDir is used for rabbitmq data when mq.storage is set to 0
     emptyDir:
@@ -938,7 +938,7 @@ deployments:
     rollout_strategy: "RollingUpdate"
     image:
       repository: lightruncom/data-streamer
-      tag: "4.97.0-alpine-3.24.1-r0.lr-0"
+      tag: "4.100.0-alpine-3.24.1-r1.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 100m
@@ -1021,7 +1021,7 @@ deployments:
       maxReplicas: 5
     image:
       repository: lightruncom/router
-      tag: "1.30.3-r0-alpine-3.24.1-r0.lr-0"
+      tag: "1.30.3-r0-alpine-3.24.1-r1.lr-0"
       pullPolicy: IfNotPresent
     podSecurityContext: {}
     containerSecurityContext: {}


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 453741 |
| **Trigger** | manual |
| **Strategy** | minor-patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=453741) |

### Chart Tag Updates

| Key | Old | New |
|---|---|---|
| deployments.backend.initContainers.p12_creator.image.tag | 0.3.0-alpine-3.24.1-r0.lr-0 | 0.3.0-alpine-3.24.1-r1.lr-0 |
| deployments.backend.initContainers.wait_for_keycloak.image.tag | 0.3.0-alpine-3.24.1-r0.lr-0 | 0.3.0-alpine-3.24.1-r1.lr-0 |
| deployments.backend.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.24.1-r0.lr-0 | 0.3.0-alpine-3.24.1-r1.lr-0 |
| deployments.data_streamer.image.tag | 4.97.0-alpine-3.24.1-r0.lr-0 | 4.100.0-alpine-3.24.1-r1.lr-0 |
| deployments.keycloak.initContainers.cluster_cert.image.tag | 0.3.0-alpine-3.24.1-r0.lr-0 | 0.3.0-alpine-3.24.1-r1.lr-0 |
| deployments.keycloak.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.24.1-r0.lr-0 | 0.3.0-alpine-3.24.1-r1.lr-0 |
| deployments.rabbitmq.image.tag | 4.3.2-alpine.lr-0 | 4.3.2-alpine.lr-1 |
| deployments.rabbitmq.initContainers.rabbitmq_config.image.tag | 0.3.0-alpine-3.24.1-r0.lr-0 | 0.3.0-alpine-3.24.1-r1.lr-0 |
| deployments.redis.image.tag | 7.4.9-alpine-3.24.1-r0.lr-0 | 7.4.9-alpine-3.24.1-r1.lr-0 |
| deployments.router.image.tag | 1.30.3-r0-alpine-3.24.1-r0.lr-0 | 1.30.3-r0-alpine-3.24.1-r1.lr-0 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | [#557](https://github.com/lightrun-platform/devops/pull/557) |
| 0/lightrun-k8s-operator | lightrun-k8s-operator | [#87](https://github.com/lightrun-platform/lightrun-k8s-operator/pull/87) |
| 1/athena | athena | [#14704](https://github.com/lightrun-platform/athena/pull/14704) |
| 1/athena-qsr | athena-qsr | [#14703](https://github.com/lightrun-platform/athena/pull/14703) |
| 1/devops | devops | [#558](https://github.com/lightrun-platform/devops/pull/558) |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | [#88](https://github.com/lightrun-platform/lightrun-k8s-operator/pull/88) |
| chart/lightrun-helm-chart | lightrun-helm-chart | _pending_ |
| chart/lightrun-helm-chart-qsr | lightrun-helm-chart-qsr | **this PR** |

### Merge Order

This PR is in **scope chart**. Merge sequence: 0 → 1 → chart.
This is the last scope — all image PRs must be merged first.
