### PR TITLE
DEVOPS-3717-added-support-topologySpreadConstraints-and-pdb

### DIFF
--- a/chart/templates/artifacts/deployment.yaml
+++ b/chart/templates/artifacts/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.deployments.artifacts.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml .Values.deployments.artifacts.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "artifacts.serviceAccountName" . }}
         {{- if .Values.deployments.artifacts.podSecurityContext }}
       securityContext:

--- a/chart/templates/pdb.yaml
+++ b/chart/templates/pdb.yaml
@@ -57,3 +57,15 @@ spec:
       app: {{ include "router.name" . }}
   {{- toYaml .Values.deployments.router.podDisruptionBudget | nindent 2 }}
 {{- end }}
+---
+{{- if .Values.deployments.artifacts.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "artifacts.name" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "artifacts.name" . }}
+  {{- toYaml .Values.deployments.artifacts.podDisruptionBudget | nindent 2 }}
+{{- end }}


### PR DESCRIPTION
Support `topologySpreadConstraints` and `podDisruptionBudget` for artifacts