### PR TITLE
DEVOPS-3727-security-bump chart-helper->0.3.0-alpine-3.24.1-r4.lr-0, data-streamer->4.102.0, rabbitmq->4.3.4-alpine, redis->7.4.10, router->1.30.4-r1

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -617,17 +617,17 @@ deployments:
       wait_for_keycloak:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r4.lr-0"
           pullPolicy: ""
       p12_creator:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r4.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r4.lr-0"
           pullPolicy: ""
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
@@ -671,12 +671,12 @@ deployments:
         download_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r4.lr-0"
             pullPolicy: ""
         persist_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r4.lr-0"
             pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
@@ -751,12 +751,12 @@ deployments:
         download_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r4.lr-0"
             pullPolicy: ""
         persist_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r4.lr-0"
             pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
@@ -801,12 +801,12 @@ deployments:
       cluster_cert:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r4.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r4.lr-0"
           pullPolicy: ""          
     topologySpreadConstraints: []
     affinity: {}
@@ -837,12 +837,12 @@ deployments:
         download_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r4.lr-0"
             pullPolicy: ""
         persist_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r4.lr-0"
             pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
@@ -882,7 +882,7 @@ deployments:
       enabled: false
     image:
       repository: lightruncom/redis
-      tag: "7.4.9-alpine-3.24.1-r3.lr-0"
+      tag: "7.4.10-alpine-3.24.1-r4.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 2000m
@@ -955,7 +955,7 @@ deployments:
     useJsonLogFormat: false
     image:
       repository: lightruncom/rabbitmq
-      tag: "4.3.3-alpine.lr-1"
+      tag: "4.3.4-alpine.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 500m
@@ -979,7 +979,7 @@ deployments:
           memory: 128Mi
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r3.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r4.lr-0"
           pullPolicy: ""
     # EmptyDir is used for rabbitmq data when mq.storage is set to 0
     emptyDir:
@@ -1017,7 +1017,7 @@ deployments:
     rollout_strategy: "RollingUpdate"
     image:
       repository: lightruncom/data-streamer
-      tag: "4.101.0-alpine-3.24.1-r3.lr-0"
+      tag: "4.102.0-alpine-3.24.1-r4.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 100m
@@ -1102,7 +1102,7 @@ deployments:
       maxReplicas: 5
     image:
       repository: lightruncom/router
-      tag: "1.30.4-r0-alpine-3.24.1-r3.lr-0"
+      tag: "1.30.4-r1-alpine-3.24.1-r4.lr-0"
       pullPolicy: IfNotPresent
     podSecurityContext: {}
     containerSecurityContext: {}


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 455940 |
| **Trigger** | manual |
| **Strategy** | minor-patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=455940) |

### Chart Tag Updates

| Key | Old | New |
|---|---|---|
| deployments.backend.asyncProfiler.initContainers.download_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.backend.asyncProfiler.initContainers.persist_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.backend.initContainers.p12_creator.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.backend.initContainers.wait_for_keycloak.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.backend.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.crons.asyncProfiler.initContainers.download_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.crons.asyncProfiler.initContainers.persist_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.data_streamer.image.tag | 4.101.0-alpine-3.24.1-r3.lr-0 | 4.102.0-alpine-3.24.1-r4.lr-0 |
| deployments.keycloak.asyncProfiler.initContainers.download_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.keycloak.asyncProfiler.initContainers.persist_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.keycloak.initContainers.cluster_cert.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.keycloak.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.rabbitmq.image.tag | 4.3.3-alpine.lr-1 | 4.3.4-alpine.lr-0 |
| deployments.rabbitmq.initContainers.rabbitmq_config.image.tag | 0.3.0-alpine-3.24.1-r3.lr-0 | 0.3.0-alpine-3.24.1-r4.lr-0 |
| deployments.redis.image.tag | 7.4.9-alpine-3.24.1-r3.lr-0 | 7.4.10-alpine-3.24.1-r4.lr-0 |
| deployments.router.image.tag | 1.30.4-r0-alpine-3.24.1-r3.lr-0 | 1.30.4-r1-alpine-3.24.1-r4.lr-0 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | [#567](https://github.com/lightrun-platform/devops/pull/567) |
| 1/athena | athena | [#14768](https://github.com/lightrun-platform/athena/pull/14768) |
| 1/athena-qsr | athena-qsr | [#14769](https://github.com/lightrun-platform/athena/pull/14769) |
| 1/devops | devops | [#568](https://github.com/lightrun-platform/devops/pull/568) |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | [#92](https://github.com/lightrun-platform/lightrun-k8s-operator/pull/92) |
| chart/lightrun-helm-chart | lightrun-helm-chart | **this PR** |
| chart/lightrun-helm-chart-qsr | lightrun-helm-chart-qsr | _pending_ |

### Merge Order

This PR is in **scope chart**. Merge sequence: 0 → 1 → chart.
This is the last scope — all image PRs must be merged first.
