### PR TITLE
DEVOPS-3785-security-bump chart-helper->0.3.0-alpine-3.24.1-r7.lr-0, data-streamer->4.104.0-alpine-3.24.1-r7.lr-0, rabbitmq->4.3.4-alpine.lr-3, redis->7.4.10-alpine-3.24.1-r7.lr-0, router->1.30.4-r1-alpine-3.24.1-r7.lr-0

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -587,17 +587,17 @@ deployments:
       wait_for_keycloak:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
           pullPolicy: ""
       p12_creator:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
           pullPolicy: ""
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
@@ -637,12 +637,12 @@ deployments:
         download_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
             pullPolicy: ""
         persist_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
             pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
@@ -712,12 +712,12 @@ deployments:
         download_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
             pullPolicy: ""
         persist_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
             pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
@@ -760,12 +760,12 @@ deployments:
       cluster_cert:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
           pullPolicy: ""
     topologySpreadConstraints: []
     affinity: {}
@@ -796,12 +796,12 @@ deployments:
         download_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
             pullPolicy: ""
         persist_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
             pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
@@ -839,7 +839,7 @@ deployments:
       enabled: false
     image:
       repository: lightruncom/redis
-      tag: "7.4.10-alpine-3.24.1-r6.lr-0"
+      tag: "7.4.10-alpine-3.24.1-r7.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 2000m
@@ -910,7 +910,7 @@ deployments:
     useJsonLogFormat: false
     image:
       repository: lightruncom/rabbitmq
-      tag: "4.3.4-alpine.lr-2"
+      tag: "4.3.4-alpine.lr-3"
       pullPolicy: IfNotPresent
     resources:
       cpu: 500m
@@ -934,7 +934,7 @@ deployments:
           memory: 128Mi
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r6.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
           pullPolicy: ""
     # EmptyDir is used for rabbitmq data when mq.storage is set to 0
     emptyDir:
@@ -971,7 +971,7 @@ deployments:
     rollout_strategy: "RollingUpdate"
     image:
       repository: lightruncom/data-streamer
-      tag: "4.104.0-alpine-3.24.1-r6.lr-0"
+      tag: "4.104.0-alpine-3.24.1-r7.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 100m
@@ -1054,7 +1054,7 @@ deployments:
       maxReplicas: 5
     image:
       repository: lightruncom/router
-      tag: "1.30.4-r1-alpine-3.24.1-r6.lr-0"
+      tag: "1.30.4-r1-alpine-3.24.1-r7.lr-0"
       pullPolicy: IfNotPresent
     podSecurityContext: {}
     containerSecurityContext: {}


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 459520 |
| **Trigger** | manual |
| **Strategy** | minor-patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=459520) |

### Chart Tag Updates

| Key | Old | New |
|---|---|---|
| deployments.backend.asyncProfiler.initContainers.download_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.backend.asyncProfiler.initContainers.persist_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.backend.initContainers.p12_creator.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.backend.initContainers.wait_for_keycloak.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.backend.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.crons.asyncProfiler.initContainers.download_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.crons.asyncProfiler.initContainers.persist_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.data_streamer.image.tag | 4.104.0-alpine-3.24.1-r6.lr-0 | 4.104.0-alpine-3.24.1-r7.lr-0 |
| deployments.keycloak.asyncProfiler.initContainers.download_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.keycloak.asyncProfiler.initContainers.persist_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.keycloak.initContainers.cluster_cert.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.keycloak.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.rabbitmq.image.tag | 4.3.4-alpine.lr-2 | 4.3.4-alpine.lr-3 |
| deployments.rabbitmq.initContainers.rabbitmq_config.image.tag | 0.3.0-alpine-3.24.1-r6.lr-0 | 0.3.0-alpine-3.24.1-r7.lr-0 |
| deployments.redis.image.tag | 7.4.10-alpine-3.24.1-r6.lr-0 | 7.4.10-alpine-3.24.1-r7.lr-0 |
| deployments.router.image.tag | 1.30.4-r1-alpine-3.24.1-r6.lr-0 | 1.30.4-r1-alpine-3.24.1-r7.lr-0 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | [#576](https://github.com/lightrun-platform/devops/pull/576) |
| 1/athena | athena | [#14833](https://github.com/lightrun-platform/athena/pull/14833) |
| 1/athena-qsr | athena-qsr | [#14832](https://github.com/lightrun-platform/athena/pull/14832) |
| 1/devops | devops | [#577](https://github.com/lightrun-platform/devops/pull/577) |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | [#95](https://github.com/lightrun-platform/lightrun-k8s-operator/pull/95) |
| chart/lightrun-helm-chart | lightrun-helm-chart | _pending_ |
| chart/lightrun-helm-chart-qsr | lightrun-helm-chart-qsr | **this PR** |

### Merge Order

This PR is in **scope chart**. Merge sequence: 0 → 1 → chart.
This is the last scope — all image PRs must be merged first.
