### PR TITLE
DEVOPS-3802-security-bump chart-helper->0.3.0-alpine-3.24.1-r8.lr-0, data-streamer->4.105.0, rabbitmq->4.3.4-alpine.lr-4, redis->7.4.10-alpine-3.24.1-r8.lr-0, router->1.30.4-r1-alpine-3.24.1-r8.lr-0

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -587,17 +587,17 @@ deployments:
       wait_for_keycloak:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r8.lr-0"
           pullPolicy: ""
       p12_creator:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r8.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r8.lr-0"
           pullPolicy: ""
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
@@ -637,12 +637,12 @@ deployments:
         download_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r8.lr-0"
             pullPolicy: ""
         persist_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r8.lr-0"
             pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
@@ -712,12 +712,12 @@ deployments:
         download_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r8.lr-0"
             pullPolicy: ""
         persist_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r8.lr-0"
             pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
@@ -760,12 +760,12 @@ deployments:
       cluster_cert:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r8.lr-0"
           pullPolicy: ""
       wait_for_rabbitmq:
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r8.lr-0"
           pullPolicy: ""
     topologySpreadConstraints: []
     affinity: {}
@@ -796,12 +796,12 @@ deployments:
         download_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r8.lr-0"
             pullPolicy: ""
         persist_async_profiler:
           image:
             repository: lightruncom/chart-helper
-            tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+            tag: "0.3.0-alpine-3.24.1-r8.lr-0"
             pullPolicy: ""
       # Download URL end point for async profiler binary, ref: https://github.com/async-profiler/async-profiler/blob/master/CHANGELOG.md
       downloadUrl: "https://github.com/async-profiler/async-profiler/releases/download/v3.0/async-profiler-3.0-linux-x64.tar.gz"
@@ -839,7 +839,7 @@ deployments:
       enabled: false
     image:
       repository: lightruncom/redis
-      tag: "7.4.10-alpine-3.24.1-r7.lr-0"
+      tag: "7.4.10-alpine-3.24.1-r8.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 2000m
@@ -910,7 +910,7 @@ deployments:
     useJsonLogFormat: false
     image:
       repository: lightruncom/rabbitmq
-      tag: "4.3.4-alpine.lr-3"
+      tag: "4.3.4-alpine.lr-4"
       pullPolicy: IfNotPresent
     resources:
       cpu: 500m
@@ -934,7 +934,7 @@ deployments:
           memory: 128Mi
         image:
           repository: lightruncom/chart-helper
-          tag: "0.3.0-alpine-3.24.1-r7.lr-0"
+          tag: "0.3.0-alpine-3.24.1-r8.lr-0"
           pullPolicy: ""
     # EmptyDir is used for rabbitmq data when mq.storage is set to 0
     emptyDir:
@@ -971,7 +971,7 @@ deployments:
     rollout_strategy: "RollingUpdate"
     image:
       repository: lightruncom/data-streamer
-      tag: "4.104.0-alpine-3.24.1-r7.lr-0"
+      tag: "4.105.0-alpine-3.24.1-r8.lr-0"
       pullPolicy: IfNotPresent
     resources:
       cpu: 100m
@@ -1054,7 +1054,7 @@ deployments:
       maxReplicas: 5
     image:
       repository: lightruncom/router
-      tag: "1.30.4-r1-alpine-3.24.1-r7.lr-0"
+      tag: "1.30.4-r1-alpine-3.24.1-r8.lr-0"
       pullPolicy: IfNotPresent
     podSecurityContext: {}
     containerSecurityContext: {}


### PR DESCRIPTION
## Cascade Run

| | |
|---|---|
| **Run ID** | 460059 |
| **Trigger** | manual |
| **Strategy** | minor-patch |
| **Pipeline** | [link](https://dev.azure.com/athenat/Athena/_build/results?buildId=460059) |

### Chart Tag Updates

| Key | Old | New |
|---|---|---|
| deployments.backend.asyncProfiler.initContainers.download_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.backend.asyncProfiler.initContainers.persist_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.backend.initContainers.p12_creator.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.backend.initContainers.wait_for_keycloak.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.backend.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.crons.asyncProfiler.initContainers.download_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.crons.asyncProfiler.initContainers.persist_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.data_streamer.image.tag | 4.104.0-alpine-3.24.1-r7.lr-0 | 4.105.0-alpine-3.24.1-r8.lr-0 |
| deployments.keycloak.asyncProfiler.initContainers.download_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.keycloak.asyncProfiler.initContainers.persist_async_profiler.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.keycloak.initContainers.cluster_cert.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.keycloak.initContainers.wait_for_rabbitmq.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.rabbitmq.image.tag | 4.3.4-alpine.lr-3 | 4.3.4-alpine.lr-4 |
| deployments.rabbitmq.initContainers.rabbitmq_config.image.tag | 0.3.0-alpine-3.24.1-r7.lr-0 | 0.3.0-alpine-3.24.1-r8.lr-0 |
| deployments.redis.image.tag | 7.4.10-alpine-3.24.1-r7.lr-0 | 7.4.10-alpine-3.24.1-r8.lr-0 |
| deployments.router.image.tag | 1.30.4-r1-alpine-3.24.1-r7.lr-0 | 1.30.4-r1-alpine-3.24.1-r8.lr-0 |

### Related PRs

| Scope | Repo | PR |
|---|---|---|
| 0/devops | devops | [#579](https://github.com/lightrun-platform/devops/pull/579) |
| 0/lightrun-k8s-operator | lightrun-k8s-operator | [#96](https://github.com/lightrun-platform/lightrun-k8s-operator/pull/96) |
| 1/athena | athena | [#14846](https://github.com/lightrun-platform/athena/pull/14846) |
| 1/athena-qsr | athena-qsr | [#14847](https://github.com/lightrun-platform/athena/pull/14847) |
| 1/devops | devops | [#580](https://github.com/lightrun-platform/devops/pull/580) |
| 1/lightrun-k8s-operator | lightrun-k8s-operator | [#97](https://github.com/lightrun-platform/lightrun-k8s-operator/pull/97) |
| chart/lightrun-helm-chart | lightrun-helm-chart | _pending_ |
| chart/lightrun-helm-chart-qsr | lightrun-helm-chart-qsr | **this PR** |

### Merge Order

This PR is in **scope chart**. Merge sequence: 0 → 1 → chart.
This is the last scope — all image PRs must be merged first.
