### PR TITLE
DEVOPS-3807-added-nodeSelector-overrides

### DIFF
--- a/chart/templates/artifacts/deployment.yaml
+++ b/chart/templates/artifacts/deployment.yaml
@@ -100,9 +100,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.general.nodeSelector }}
+      {{- with coalesce .Values.deployments.artifacts.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.general.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.artifacts.affinity }}
       affinity:

--- a/chart/templates/backend-deployment.yaml
+++ b/chart/templates/backend-deployment.yaml
@@ -169,9 +169,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.general.nodeSelector }}
+      {{- with coalesce .Values.deployments.backend.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.general.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.backend.affinity }}
       affinity:

--- a/chart/templates/crons/deployment.yaml
+++ b/chart/templates/crons/deployment.yaml
@@ -159,9 +159,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.general.nodeSelector }}
+      {{- with coalesce .Values.deployments.crons.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.general.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.crons.affinity }}
       affinity:

--- a/chart/templates/data_streamer/deployment.yaml
+++ b/chart/templates/data_streamer/deployment.yaml
@@ -87,9 +87,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.general.nodeSelector }}
+      {{- with coalesce .Values.deployments.data_streamer.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.general.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.data_streamer.affinity }}
       affinity:

--- a/chart/templates/frontend-deployment.yaml
+++ b/chart/templates/frontend-deployment.yaml
@@ -125,9 +125,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.general.nodeSelector }}
+      {{- with coalesce .Values.deployments.frontend.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.general.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.frontend.affinity }}
       affinity:

--- a/chart/templates/keycloak-statefulset.yaml
+++ b/chart/templates/keycloak-statefulset.yaml
@@ -350,9 +350,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.general.nodeSelector }}
+      {{- with coalesce .Values.deployments.keycloak.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.general.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.keycloak.affinity }}
       affinity:

--- a/chart/templates/mysql.yaml
+++ b/chart/templates/mysql.yaml
@@ -157,9 +157,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.deployments.mysql.nodeSelector }}
+      {{- with coalesce .Values.deployments.mysql.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.deployments.mysql.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.mysql.affinity }}
       affinity:

--- a/chart/templates/rabbitmq.yaml
+++ b/chart/templates/rabbitmq.yaml
@@ -159,9 +159,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.deployments.rabbitmq.nodeSelector }}
+      {{- with coalesce .Values.deployments.rabbitmq.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.deployments.rabbitmq.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.rabbitmq.affinity }}
       affinity:

--- a/chart/templates/redis-deployment.yaml
+++ b/chart/templates/redis-deployment.yaml
@@ -98,9 +98,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.general.nodeSelector }}
+      {{- with coalesce .Values.deployments.redis.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.general.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.redis.affinity }}
       affinity:

--- a/chart/templates/router/deployment.yaml
+++ b/chart/templates/router/deployment.yaml
@@ -122,9 +122,9 @@ spec:
       tolerations:
         {{ toYaml .Values.general.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.general.nodeSelector }}
+      {{- with coalesce .Values.deployments.router.nodeSelector .Values.general.nodeSelector }}
       nodeSelector:
-        {{ toYaml .Values.general.nodeSelector  | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.deployments.router.affinity }}
       affinity:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -275,8 +275,8 @@ general:
 
   nodeSelector: {}
   #   purpose: stage
-  ## If you want to set node selector for Lightrun deployments, delete the `{}` in the line above
-  ## and uncomment this example block
+  ## Applied to all Lightrun deployments/statefulsets. Override per workload with
+  ## deployments.<name>.nodeSelector. Delete the `{}` above and uncomment this example block
   #  label-key1: "label-value1"
   #  label-key2: "label-value2"
 
@@ -560,6 +560,8 @@ deployments:
     extraVolumeMounts: []
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
+    nodeSelector: {}
     affinity: {}
     livenessProbe:
       initialDelaySeconds: 10
@@ -631,6 +633,8 @@ deployments:
           pullPolicy: ""
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
+    nodeSelector: {}
     affinity: {}
     lifecycle:
       preStop:
@@ -712,6 +716,8 @@ deployments:
     extraVolumes: []
     extraVolumeMounts: []
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
+    nodeSelector: {}
     affinity: {}
     lifecycle:
       preStop:
@@ -809,6 +815,8 @@ deployments:
           tag: "0.3.0-alpine-3.24.1-r8.lr-0"
           pullPolicy: ""          
     topologySpreadConstraints: []
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
+    nodeSelector: {}
     affinity: {}
     startupProbe:
       initialDelaySeconds: 10
@@ -898,6 +906,8 @@ deployments:
     # EmptyDir is used for redis data persistence
     emptyDir:
       sizeLimit: 5Gi
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
+    nodeSelector: {}
     affinity: {}
     livenessProbe:
       initialDelaySeconds: 50
@@ -913,6 +923,7 @@ deployments:
       failureThreshold: 3
 
   mysql:
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
     nodeSelector: {}
     podSecurityContext:
       # when using PVC , it is necessarily to set fsGroup so pod will have write permission to the mounted volume
@@ -966,6 +977,7 @@ deployments:
       annotations: {}
       labels: {}
       ## prometheus autodiscovery annotations could be added to the service
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
     nodeSelector: {}
     podSecurityContext:
       # when using PVC , it is necessarily to set fsGroup so pod will have write permission to the mounted volume
@@ -1035,6 +1047,8 @@ deployments:
     extraVolumeMounts: []
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
+    nodeSelector: {}
     affinity: {}
     livenessProbe:
       initialDelaySeconds: 10
@@ -1076,6 +1090,8 @@ deployments:
     extraVolumeMounts: []
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
+    nodeSelector: {}
     affinity: {}
     livenessProbe: 
       initialDelaySeconds: 10
@@ -1118,6 +1134,8 @@ deployments:
       https: 8443
     podDisruptionBudget: {} # [minAvailable|maxUnavailable] either integer or percentage
     topologySpreadConstraints: []
+    # Optional override of general.nodeSelector. If empty, general.nodeSelector is used.
+    nodeSelector: {}
     affinity: {}
     livenessProbe:
       initialDelaySeconds: 10


### PR DESCRIPTION
DEVOPS-3807
1. apply `general.nodeSelector` to mysql and rabbitmq 
2. for all other services - set specific nodeSelector